### PR TITLE
Rest of World - Implement fallback to yield localized prices using default country price with converted rate

### DIFF
--- a/src/main/scala/io/flow/localization/rates/Localizer.scala
+++ b/src/main/scala/io/flow/localization/rates/Localizer.scala
@@ -156,8 +156,11 @@ class LocalizerImpl @Inject() (dataClient: DataClient, rateProvider: RateProvide
       case None => {
         val futureOptionalPriceUsa = dataClient.get[Array[Byte]](getUsaKey(itemNumber))
         val optionalFlowSkuPrice = futureOptionalPriceUsa.map(toFlowSkuPrice)
-        val targetCurrency = Countries.mustFind(country).defaultCurrency
-        optionalFlowSkuPrice.map(convertToFlowSkuPrice(_, targetCurrency))
+
+        Countries.find(country).map { foundCountry =>
+          val currency = foundCountry.defaultCurrency
+          optionalFlowSkuPrice.map(convertToFlowSkuPrice(_, currency))
+        }.getOrElse(Future.successful { None })
       }
     }
   }

--- a/src/main/scala/io/flow/localization/rates/Localizer.scala
+++ b/src/main/scala/io/flow/localization/rates/Localizer.scala
@@ -123,11 +123,7 @@ class LocalizerImpl @Inject() (dataClient: DataClient, rateProvider: RateProvide
 
   override def getSkuPriceByCountry(country: String, itemNumber: String)(
     implicit executionContext: ExecutionContext
-  ): Future[Option[FlowSkuPrice]] = {
-    val key = getKey(country, itemNumber)
-    val defaultCurrency = Countries.mustFind(country).defaultCurrency
-    getPricing(country, itemNumber)
-  }
+  ): Future[Option[FlowSkuPrice]] = getPricing(country, itemNumber)
 
   override def getSkuPricesByCountry(country: String, itemNumbers: Iterable[String])(
     implicit executionContext: ExecutionContext

--- a/src/main/scala/io/flow/localization/rates/Localizer.scala
+++ b/src/main/scala/io/flow/localization/rates/Localizer.scala
@@ -24,7 +24,7 @@ trait Localizer {
     * @param itemNumbers the item numbers to localize
     * @return the localized pricing of the specified items for the specified country
     */
-  def getSkuPricesByCountry(country: String, itemNumbers: Iterable[String])(
+  def getPricings(country: String, itemNumbers: Iterable[String])(
     implicit executionContext: ExecutionContext
   ): Future[List[Option[FlowSkuPrice]]]
 
@@ -36,7 +36,7 @@ trait Localizer {
     * @param itemNumber the item number to localize
     * @return the localized pricing of the specified item for the specified country
     */
-  def getSkuPriceByCountry(country: String, itemNumber: String)(
+  def getPricing(country: String, itemNumber: String)(
     implicit executionContext: ExecutionContext
   ): Future[Option[FlowSkuPrice]]
 
@@ -52,7 +52,7 @@ trait Localizer {
   def getSkuPriceByCountryWithCurrency(country: String, itemNumber: String, targetCurrency: String)(
     implicit executionContext: ExecutionContext
   ): Future[Option[FlowSkuPrice]] = {
-    getSkuPriceByCountry(country, itemNumber).map(_.map(convert(_, targetCurrency)))
+    getPricing(country, itemNumber).map(_.map(convert(_, targetCurrency)))
   }
 
   /**
@@ -67,7 +67,7 @@ trait Localizer {
   def getSkuPricesByCountryWithCurrency(country: String, itemNumbers: Iterable[String], targetCurrency: String)(
     implicit executionContext: ExecutionContext
   ): Future[List[Option[FlowSkuPrice]]] = {
-    getSkuPricesByCountry(country, itemNumbers).map(_.map(_.map(convert(_, targetCurrency))))
+    getPricings(country, itemNumbers).map(_.map(_.map(convert(_, targetCurrency))))
   }
 
   /**
@@ -121,15 +121,7 @@ class LocalizerImpl @Inject() (dataClient: DataClient, rateProvider: RateProvide
 
   private val mapper = new ObjectMapper(new MessagePackFactory())
 
-  override def getSkuPriceByCountry(country: String, itemNumber: String)(
-    implicit executionContext: ExecutionContext
-  ): Future[Option[FlowSkuPrice]] = getPricing(country, itemNumber)
-
-  override def getSkuPricesByCountry(country: String, itemNumbers: Iterable[String])(
-    implicit executionContext: ExecutionContext
-  ): Future[List[Option[FlowSkuPrice]]] = getPricings(country, itemNumbers)
-
-  private def getPricings(country: String, itemNumbers: Iterable[String])(
+  override def getPricings(country: String, itemNumbers: Iterable[String])(
     implicit executionContext: ExecutionContext
   ): Future[List[Option[FlowSkuPrice]]] = {
     val futureOptionalPrices = dataClient.mGet[Array[Byte]](itemNumbers.map(getKey(country, _)).toSeq)
@@ -149,7 +141,7 @@ class LocalizerImpl @Inject() (dataClient: DataClient, rateProvider: RateProvide
     }
   }
 
-  private def getPricing(country: String, itemNumber: String)(
+  override def getPricing(country: String, itemNumber: String)(
     implicit executionContext: ExecutionContext
   ): Future[Option[FlowSkuPrice]] = {
     dataClient.get[Array[Byte]](getKey(country, itemNumber)).flatMap {

--- a/src/main/scala/io/flow/localization/rates/Localizer.scala
+++ b/src/main/scala/io/flow/localization/rates/Localizer.scala
@@ -135,7 +135,7 @@ class LocalizerImpl @Inject() (dataClient: DataClient, rateProvider: RateProvide
     val futureOptionalPrices = dataClient.mGet[Array[Byte]](itemNumbers.map(getKey(country, _)).toSeq)
 
     futureOptionalPrices.flatMap { optionalPrices =>
-      optionalPrices.map(toFlowSkuPrice) match {
+      optionalPrices.flatMap(toFlowSkuPrice) match {
         case Nil => {
           val futureOptionalPricesUsa = dataClient.mGet[Array[Byte]](itemNumbers.map(getUsaKey).toSeq)
           futureOptionalPricesUsa.map { optionalPrices =>
@@ -144,7 +144,7 @@ class LocalizerImpl @Inject() (dataClient: DataClient, rateProvider: RateProvide
             optionalFlowSkuPrices.map(convertToFlowSkuPrice(_, targetCurrency)).toList
           }
         }
-        case prices => Future.successful { prices.toList }
+        case prices => Future.successful { prices.map(Option(_)).toList }
       }
     }
   }

--- a/src/main/scala/io/flow/localization/rates/Localizer.scala
+++ b/src/main/scala/io/flow/localization/rates/Localizer.scala
@@ -8,7 +8,7 @@ import io.flow.localization.countries.{AvailableCountriesProvider, AvailableCoun
 import io.flow.localization.pricing.FlowSkuPrice
 import io.flow.localization.utils.{DataClient, RedisDataClient}
 import io.flow.reference.Countries
-import io.flow.reference.data.{Countries => CountriesData, Currencies => CurrenciesData}
+import io.flow.reference.data.{Countries => CountriesData}
 import org.msgpack.jackson.dataformat.MessagePackFactory
 
 import scala.concurrent.duration._

--- a/src/test/scala/io/flow/localization/rates/LocalizerSpec.scala
+++ b/src/test/scala/io/flow/localization/rates/LocalizerSpec.scala
@@ -265,6 +265,35 @@ class LocalizerSpec extends WordSpec with MockitoSugar with Matchers with ScalaF
       }
     }
 
+    "retrieve and convert localized pricings by default country" in {
+      val dataClient = mock[DataClient]
+      val rateProvider = mock[RateProvider]
+
+      val country = Countries.Fra.iso31663
+      val defaultCountry = Countries.Usa.iso31663
+      val itemNumber1 = "item1"
+      val itemNumber2 = "item2"
+
+      val key1 = s"c-$country:$itemNumber1"
+      val key2 = s"c-$country:$itemNumber2"
+      val defaultKey1 = s"c-$defaultCountry:$itemNumber1"
+      val defaultKey2 = s"c-$defaultCountry:$itemNumber2"
+      val value: Array[Byte] = new ObjectMapper(new MessagePackFactory()).writeValueAsBytes(pricing50Usa)
+
+      when(dataClient.mGet[Array[Byte]](Seq(key1, key2))).thenReturn(Future.successful(Seq(None, None)))
+      when(dataClient.mGet[Array[Byte]](Seq(defaultKey1, defaultKey2))).thenReturn(Future.successful(Seq(Some(value), Some(value))))
+      when(rateProvider.get(any(), any())).thenReturn(Some(BigDecimal(0.5)))
+
+      val localizer = new LocalizerImpl(dataClient, rateProvider, mock[AvailableCountriesProvider])
+
+      whenReady(localizer.getSkuPricesByCountryWithCurrency(country, itemNumbers = Seq(itemNumber1, itemNumber2),
+        targetCurrency = Currencies.Eur.iso42173)) { res =>
+        res should have size 2
+        res(0) shouldBe FlowSkuPrice(pricing25Eur)
+        res(1) shouldBe FlowSkuPrice(pricing25Eur)
+      }
+    }
+
   }
 
 }

--- a/src/test/scala/io/flow/localization/rates/LocalizerSpec.scala
+++ b/src/test/scala/io/flow/localization/rates/LocalizerSpec.scala
@@ -75,13 +75,13 @@ class LocalizerSpec extends WordSpec with MockitoSugar with Matchers with ScalaF
       val expected = FlowSkuPrice(pricing50Cad).get
 
       // Verify we can retrieve by iso31663 code
-      whenReady(localizer.getSkuPriceByCountry(Countries.Can.iso31663, itemNumber = itemNumber)) { res =>
+      whenReady(localizer.getPricing(Countries.Can.iso31663, itemNumber = itemNumber)) { res =>
         res shouldBe Some(expected)
         res.get.msrpPrice.get shouldBe expected.msrpPrice.get
       }
 
       // Verify we can retrieve by iso31662 code lowercase
-      whenReady(localizer.getSkuPriceByCountry(Countries.Can.iso31662.toLowerCase, itemNumber = itemNumber)) { res =>
+      whenReady(localizer.getPricing(Countries.Can.iso31662.toLowerCase, itemNumber = itemNumber)) { res =>
         res shouldBe Some(expected)
         res.get.msrpPrice.get shouldBe expected.msrpPrice.get
       }
@@ -100,7 +100,7 @@ class LocalizerSpec extends WordSpec with MockitoSugar with Matchers with ScalaF
 
       val expected = FlowSkuPrice(deserializedPricing).get
 
-      whenReady(localizer.getSkuPriceByCountry(Countries.Can.iso31663, itemNumber = itemNumber)) { res =>
+      whenReady(localizer.getPricing(Countries.Can.iso31663, itemNumber = itemNumber)) { res =>
         res shouldBe Some(expected)
         res.get.msrpPrice.get shouldBe expected.msrpPrice.get
       }
@@ -220,13 +220,13 @@ class LocalizerSpec extends WordSpec with MockitoSugar with Matchers with ScalaF
       val expected = FlowSkuPrice(pricing50Cad).get
 
       // Verify we can retrieve by iso31663 code
-      whenReady(localizer.getSkuPriceByCountry(Countries.Can.iso31663, itemNumber = itemNumber)) { res =>
+      whenReady(localizer.getPricing(Countries.Can.iso31663, itemNumber = itemNumber)) { res =>
         res shouldBe Some(expected)
         res.get.msrpPrice.get shouldBe expected.msrpPrice.get
       }
 
       // Verify we can retrieve by iso31662 code lowercase
-      whenReady(localizer.getSkuPriceByCountry(Countries.Can.iso31662.toLowerCase, itemNumber = itemNumber)) { res =>
+      whenReady(localizer.getPricing(Countries.Can.iso31662.toLowerCase, itemNumber = itemNumber)) { res =>
         res shouldBe Some(expected)
         res.get.msrpPrice.get shouldBe expected.msrpPrice.get
       }


### PR DESCRIPTION
Intended to be used as the first pass solution to support `world`.

Given a `world` experience with `"country": "USA"`, Redis will "just work" and populated keys as `c-usa-<item_number>`.  

Given an `organization_region_setting` to enable `world`, all calls will be made through `Flow Localizer`

If "default" country key does not yield a result, the item price will come from the `USA` key and then converted given the `target currency`.  This will show a localized price in the customers expected currency when an explicit experience does not exist.